### PR TITLE
fix: 模範解答が clone 直後に動かない/テストが走らない/pint を通らない 3点を直す

### DIFF
--- a/app/Actions/Fortify/PasswordValidationRules.php
+++ b/app/Actions/Fortify/PasswordValidationRules.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Fortify;
 
+use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Validation\Rules\Password;
 
 trait PasswordValidationRules
@@ -9,7 +10,7 @@ trait PasswordValidationRules
     /**
      * Get the validation rules used to validate passwords.
      *
-     * @return array<int, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<int, Rule|array|string>
      */
     protected function passwordRules(): array
     {

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -17,7 +17,7 @@ class AdminController extends Controller
      * 指定日の全ユーザーの勤怠一覧を表示する。
      *
      * @param  Request  $request  日付（date）を含むリクエスト
-     * @return View  勤怠一覧画面のビュー
+     * @return View 勤怠一覧画面のビュー
      */
     public function list(Request $request): View
     {
@@ -38,7 +38,7 @@ class AdminController extends Controller
     /**
      * スタッフ（一般ユーザー）一覧を表示する。
      *
-     * @return View  スタッフ一覧画面のビュー
+     * @return View スタッフ一覧画面のビュー
      */
     public function staffList(): View
     {
@@ -53,7 +53,7 @@ class AdminController extends Controller
      *
      * @param  Request  $request  対象月（date）を含むリクエスト
      * @param  int  $id  対象スタッフのユーザーID
-     * @return View  スタッフ別月次勤怠一覧画面のビュー
+     * @return View スタッフ別月次勤怠一覧画面のビュー
      */
     public function staffDetailList(Request $request, int $id): View
     {
@@ -77,7 +77,7 @@ class AdminController extends Controller
             $record = $records->get($day->format('Y-m-d'));
             $formattedAttendanceRecords->push([
                 'id' => $record?->id,
-                'date' => $day->format('m/d') . "({$weekdays[$day->dayOfWeek]})",
+                'date' => $day->format('m/d')."({$weekdays[$day->dayOfWeek]})",
                 'clock_in' => $record?->clock_in ? Carbon::parse($record->clock_in)->format('H:i') : null,
                 'clock_out' => $record?->clock_out ? Carbon::parse($record->clock_out)->format('H:i') : null,
                 'total_time' => $record?->total_time,
@@ -92,7 +92,7 @@ class AdminController extends Controller
                 'date' => $date,
                 'formattedAttendanceRecords' => $formattedAttendanceRecords,
                 'previousMonth' => $date->copy()->subMonth()->format('Y-m'),
-                'nextMonth' => $date->copy()->addMonth()->format('Y-m')
+                'nextMonth' => $date->copy()->addMonth()->format('Y-m'),
             ]
         );
     }
@@ -101,7 +101,7 @@ class AdminController extends Controller
      * 管理者向けの勤怠詳細画面を表示する。
      *
      * @param  int  $id  対象の勤怠レコードID
-     * @return View  勤怠詳細画面のビュー
+     * @return View 勤怠詳細画面のビュー
      */
     public function detail(int $id): View
     {
@@ -138,7 +138,7 @@ class AdminController extends Controller
      *
      * @param  CorrectionRequest  $request  修正後の日付・出退勤・休憩・備考を含むリクエスト
      * @param  int  $id  対象の勤怠レコードID
-     * @return View  修正後の勤怠詳細画面のビュー
+     * @return View 修正後の勤怠詳細画面のビュー
      */
     public function amendmentApplication(CorrectionRequest $request, int $id): View
     {
@@ -169,7 +169,7 @@ class AdminController extends Controller
         $totalBreakMinutes = 0;
 
         for ($i = 0; $i < count($breakIns); $i++) {
-            if (!empty($breakIns[$i]) && !empty($breakOuts[$i])) {
+            if (! empty($breakIns[$i]) && ! empty($breakOuts[$i])) {
                 $breakIn = Carbon::parse($breakIns[$i])->format('H:i');
                 $breakOut = Carbon::parse($breakOuts[$i])->format('H:i');
 
@@ -197,12 +197,13 @@ class AdminController extends Controller
     /**
      * 修正申請一覧（全ユーザー）を表示する。
      *
-     * @return View  修正申請一覧画面のビュー
+     * @return View 修正申請一覧画面のビュー
      */
     public function applicationList(): View
     {
         $user = User::all();
         $applications = Application::all();
+
         return view('admin/admin-application-list', compact('user', 'applications'));
     }
 
@@ -210,7 +211,7 @@ class AdminController extends Controller
      * 修正申請の承認画面を表示する。
      *
      * @param  int  $id  対象の修正申請ID
-     * @return View  修正申請の承認画面のビュー
+     * @return View 修正申請の承認画面のビュー
      */
     public function approvalShow(int $id): View
     {
@@ -231,7 +232,7 @@ class AdminController extends Controller
      *
      * @param  Request  $request  リクエスト（承認処理では未使用）
      * @param  int  $id  対象の修正申請ID
-     * @return View  修正申請一覧画面のビュー
+     * @return View 修正申請一覧画面のビュー
      */
     public function approval(Request $request, int $id): View
     {
@@ -239,7 +240,7 @@ class AdminController extends Controller
         $user = User::findOrFail($application->user_id);
         $attendanceRecord = AttendanceRecord::findOrFail($application->attendance_record_id);
 
-        $application->approval_status = "承認済み";
+        $application->approval_status = '承認済み';
         $application->save();
 
         $attendanceRecord->date = $application->new_date;
@@ -288,7 +289,7 @@ class AdminController extends Controller
      * 指定スタッフ・月の勤怠を CSV で出力する。
      *
      * @param  Request  $request  対象ユーザーID（user_id）と対象月（year_month）を含むリクエスト
-     * @return Response  CSV ファイルのダウンロードレスポンス
+     * @return Response CSV ファイルのダウンロードレスポンス
      */
     public function export(Request $request): Response
     {
@@ -307,7 +308,7 @@ class AdminController extends Controller
             '出勤時間',
             '退勤時間',
             '休憩時間',
-            '勤務時間'
+            '勤務時間',
         ];
         $temps = [];
         array_push($temps, $csvHeader);
@@ -318,7 +319,7 @@ class AdminController extends Controller
                 Carbon::parse($staff->clock_in)->format('H:i'),
                 Carbon::parse($staff->clock_out)->format('H:i'),
                 $staff->total_break_time,
-                $staff->total_time
+                $staff->total_time,
             ];
             array_push($temps, $temp);
         }
@@ -330,10 +331,11 @@ class AdminController extends Controller
         $csv = str_replace(PHP_EOL, "\r\n", stream_get_contents($stream));
         $csv = mb_convert_encoding($csv, 'SJIS-win', 'UTF-8');
         $filename = "{$userName}さんの勤怠リスト.csv";
-        $headers = array(
+        $headers = [
             'Content-Type' => 'text/csv',
-            'Content-Disposition' => 'attachment; filename=' . $filename,
-        );
+            'Content-Disposition' => 'attachment; filename='.$filename,
+        ];
+
         return response($csv, 200, $headers);
     }
 }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -28,7 +28,7 @@ class AuthController extends Controller
     /**
      * 管理者ログイン画面を表示する。
      *
-     * @return View  管理者ログイン画面のビュー
+     * @return View 管理者ログイン画面のビュー
      */
     public function adminLogin(): View
     {
@@ -39,7 +39,7 @@ class AuthController extends Controller
      * 管理者ログインを実行する。管理者でなければログインさせない。
      *
      * @param  AdminLoginRequest  $request  メールアドレス・パスワードを含むログインリクエスト
-     * @return RedirectResponse  勤怠一覧へのリダイレクト、または認証失敗時の差し戻し
+     * @return RedirectResponse 勤怠一覧へのリダイレクト、または認証失敗時の差し戻し
      */
     public function adminDoLogin(AdminLoginRequest $request): RedirectResponse
     {
@@ -50,24 +50,27 @@ class AuthController extends Controller
                 return redirect('admin/attendance/list');
             } else {
                 Auth::logout();
+
                 return redirect()->back()->withErrors([
-                    'email' => 'ログイン情報が登録されていません'
+                    'email' => 'ログイン情報が登録されていません',
                 ]);
             }
         }
+
         return redirect()->back()->withErrors([
-            'email' => 'ログイン情報が登録されていません'
+            'email' => 'ログイン情報が登録されていません',
         ])->withInput();
     }
 
     /**
      * 管理者をログアウトする。
      *
-     * @return RedirectResponse  管理者ログイン画面へのリダイレクト
+     * @return RedirectResponse 管理者ログイン画面へのリダイレクト
      */
     public function adminLogout(): RedirectResponse
     {
         Auth::logout();
+
         return redirect('/admin/login');
     }
 
@@ -75,7 +78,7 @@ class AuthController extends Controller
      * 会員登録を行い、認証メールを送信したうえでメール認証誘導画面へ遷移する。
      *
      * @param  RegisterRequest  $request  名前・メールアドレス・パスワードを含む登録リクエスト
-     * @return RedirectResponse  メール認証誘導画面へのリダイレクト
+     * @return RedirectResponse メール認証誘導画面へのリダイレクト
      */
     public function store(RegisterRequest $request): RedirectResponse
     {
@@ -92,7 +95,7 @@ class AuthController extends Controller
      * 一般ユーザーのログインを実行する。メール未認証の場合はログインさせず認証メールを再送する。
      *
      * @param  LoginRequest  $request  メールアドレス・パスワードを含むログインリクエスト
-     * @return RedirectResponse  勤怠打刻画面へのリダイレクト、または認証失敗時の差し戻し
+     * @return RedirectResponse 勤怠打刻画面へのリダイレクト、または認証失敗時の差し戻し
      */
     public function doLogin(LoginRequest $request): RedirectResponse
     {
@@ -104,26 +107,29 @@ class AuthController extends Controller
             if (! $user->hasVerifiedEmail()) {
                 Auth::logout();
                 $this->sendVerificationEmail($user);
+
                 return redirect()->back()->withErrors([
-                    'email' => 'メール認証が必要です。認証メールを再送信しました。'
+                    'email' => 'メール認証が必要です。認証メールを再送信しました。',
                 ]);
             }
+
             return redirect()->intended('/attendance');
         }
 
         return redirect()->back()->withErrors([
-            'email' => 'ログイン情報が登録されていません'
+            'email' => 'ログイン情報が登録されていません',
         ]);
     }
 
     /**
      * 一般ユーザーをログアウトする。
      *
-     * @return RedirectResponse  ログイン画面へのリダイレクト
+     * @return RedirectResponse ログイン画面へのリダイレクト
      */
     public function doLogout(): RedirectResponse
     {
         Auth::logout();
+
         return redirect('/login');
     }
 
@@ -131,7 +137,6 @@ class AuthController extends Controller
      * 指定ユーザーへメール認証通知を送信する。
      *
      * @param  User  $user  認証メールの送信先ユーザー
-     * @return void
      */
     protected function sendVerificationEmail(User $user): void
     {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -16,7 +16,7 @@ class UserController extends Controller
     /**
      * 勤怠打刻画面を表示する。
      *
-     * @return View  勤怠打刻画面のビュー
+     * @return View 勤怠打刻画面のビュー
      */
     public function index(): View
     {
@@ -33,7 +33,7 @@ class UserController extends Controller
             }
         }
 
-        $now = new \DateTime();
+        $now = new \DateTime;
         $week = [
             0 => '日', 1 => '月', 2 => '火', 3 => '水',
             4 => '木', 5 => '金', 6 => '土',
@@ -52,7 +52,7 @@ class UserController extends Controller
      * 出勤・退勤・休憩入・休憩戻の打刻を処理する。
      *
      * @param  Request  $request  打刻種別（action）を含むリクエスト
-     * @return RedirectResponse  勤怠打刻画面へのリダイレクト
+     * @return RedirectResponse 勤怠打刻画面へのリダイレクト
      */
     public function attendance(Request $request): RedirectResponse
     {
@@ -63,15 +63,15 @@ class UserController extends Controller
             ->whereDate('date', now()->toDateString())
             ->first();
 
-        if (in_array($action, ['break_in','break_out','clock_out']) && ! $attendance) {
+        if (in_array($action, ['break_in', 'break_out', 'clock_out']) && ! $attendance) {
             return redirect('/attendance')->withErrors('出勤していません。先に「出勤」をしてください。');
         }
 
         if ($action === 'clock_in' && $user->attendance_status === '勤務外') {
-            $attendance             = new AttendanceRecord();
-            $attendance->user_id    = $user->id;
-            $attendance->date       = now();
-            $attendance->clock_in   = Carbon::now();
+            $attendance = new AttendanceRecord;
+            $attendance->user_id = $user->id;
+            $attendance->date = now();
+            $attendance->clock_in = Carbon::now();
             $attendance->save();
 
             $user->attendance_status = '出勤中';
@@ -103,7 +103,7 @@ class UserController extends Controller
         } elseif ($action === 'clock_out' && $user->attendance_status === '出勤中') {
             $attendance->clock_out = Carbon::now();
 
-            $clockIn  = Carbon::parse($attendance->clock_in);
+            $clockIn = Carbon::parse($attendance->clock_in);
             $clockOut = Carbon::parse($attendance->clock_out);
 
             $totalBreakTime = 0;
@@ -116,15 +116,15 @@ class UserController extends Controller
 
             $attendance->total_break_time = sprintf(
                 '%02d:%02d',
-                floor($totalBreakTime/60),
-                $totalBreakTime%60
+                floor($totalBreakTime / 60),
+                $totalBreakTime % 60
             );
 
             $workedMins = $clockIn->diffInMinutes($clockOut) - $totalBreakTime;
             $attendance->total_time = sprintf(
                 '%02d:%02d',
-                floor($workedMins/60),
-                $workedMins%60
+                floor($workedMins / 60),
+                $workedMins % 60
             );
 
             $attendance->save();
@@ -140,7 +140,7 @@ class UserController extends Controller
      * ログインユーザーの月次勤怠一覧を表示する（当該月の全日付・勤怠がない日は空欄）。
      *
      * @param  Request  $request  対象月（date）を含むリクエスト
-     * @return View  月次勤怠一覧画面のビュー
+     * @return View 月次勤怠一覧画面のビュー
      */
     public function list(Request $request): View
     {
@@ -148,7 +148,7 @@ class UserController extends Controller
         $date = Carbon::parse($request->query('date', now()));
 
         $startOfMonth = $date->copy()->startOfMonth();
-        $endOfMonth   = $date->copy()->endOfMonth();
+        $endOfMonth = $date->copy()->endOfMonth();
 
         // N+1 を避けるため breaks を Eager Load し、日付をキーに引けるようにする
         $records = AttendanceRecord::with('breaks')
@@ -158,24 +158,24 @@ class UserController extends Controller
             ->keyBy(fn ($rec) => Carbon::parse($rec->date)->format('Y-m-d'));
 
         // 当該月の1ヶ月分すべての日付を行として並べる（勤怠がない日は空欄）
-        $weekdays = ['日','月','火','水','木','金','土'];
+        $weekdays = ['日', '月', '火', '水', '木', '金', '土'];
         $formatted = collect();
         for ($day = $startOfMonth->copy(); $day->lte($endOfMonth); $day->addDay()) {
             $record = $records->get($day->format('Y-m-d'));
             $formatted->push([
-                'id'               => $record?->id,
-                'date'             => $day->format('m/d') . "({$weekdays[$day->dayOfWeek]})",
-                'clock_in'         => $record?->clock_in  ? Carbon::parse($record->clock_in)->format('H:i') : null,
-                'clock_out'        => $record?->clock_out ? Carbon::parse($record->clock_out)->format('H:i') : null,
-                'total_time'       => $record?->total_time,
+                'id' => $record?->id,
+                'date' => $day->format('m/d')."({$weekdays[$day->dayOfWeek]})",
+                'clock_in' => $record?->clock_in ? Carbon::parse($record->clock_in)->format('H:i') : null,
+                'clock_out' => $record?->clock_out ? Carbon::parse($record->clock_out)->format('H:i') : null,
+                'total_time' => $record?->total_time,
                 'total_break_time' => $record?->total_break_time,
             ]);
         }
 
         return view('user/user-attendance-list', [
             'formattedAttendanceRecords' => $formatted,
-            'date'          => $date,
-            'nextMonth'     => $date->copy()->addMonth()->format('Y-m'),
+            'date' => $date,
+            'nextMonth' => $date->copy()->addMonth()->format('Y-m'),
             'previousMonth' => $date->copy()->subMonth()->format('Y-m'),
         ]);
     }
@@ -184,7 +184,7 @@ class UserController extends Controller
      * 勤怠詳細画面を表示する。承認待ち申請がある場合はその内容を併せて渡す。
      *
      * @param  int  $id  対象の勤怠レコードID
-     * @return View  勤怠詳細画面のビュー
+     * @return View 勤怠詳細画面のビュー
      */
     public function detail(int $id): View
     {
@@ -194,7 +194,7 @@ class UserController extends Controller
         // マスター休憩
         $masterBreaks = $attendanceRecord->breaks()->get()->map(function ($break) {
             return [
-                'break_in'  => $break->break_in ? Carbon::parse($break->break_in)->format('H:i') : null,
+                'break_in' => $break->break_in ? Carbon::parse($break->break_in)->format('H:i') : null,
                 'break_out' => $break->break_out ? Carbon::parse($break->break_out)->format('H:i') : null,
             ];
         })->toArray();
@@ -207,30 +207,30 @@ class UserController extends Controller
         if ($application) {
             $proposal = $application->proposalBreaks()->get()->map(function ($break) {
                 return [
-                    'break_in'  => Carbon::parse($break->break_in)->format('H:i'),
+                    'break_in' => Carbon::parse($break->break_in)->format('H:i'),
                     'break_out' => $break->break_out ? Carbon::parse($break->break_out)->format('H:i') : null,
                 ];
             })->toArray();
         }
 
         $data = [
-            'id'            => $attendanceRecord->id,
-            'year'          => $attendanceRecord->date
+            'id' => $attendanceRecord->id,
+            'year' => $attendanceRecord->date
                                 ? Carbon::parse($attendanceRecord->date)->format('Y年')
                                 : null,
-            'date'          => $attendanceRecord->date
+            'date' => $attendanceRecord->date
                                 ? Carbon::parse($attendanceRecord->date)->format('n月j日')
                                 : null,
-            'clock_in'      => $attendanceRecord->clock_in
+            'clock_in' => $attendanceRecord->clock_in
                                 ? Carbon::parse($attendanceRecord->clock_in)->format('H:i')
                                 : null,
-            'clock_out'     => $attendanceRecord->clock_out
+            'clock_out' => $attendanceRecord->clock_out
                                 ? Carbon::parse($attendanceRecord->clock_out)->format('H:i')
                                 : null,
-            'breaks'        => $masterBreaks,
-            'proposal_breaks'=> $proposal,
-            'comment'       => $attendanceRecord->comment,
-            'application'   => $application,
+            'breaks' => $masterBreaks,
+            'proposal_breaks' => $proposal,
+            'comment' => $attendanceRecord->comment,
+            'application' => $application,
         ];
 
         return view('user/user-detail', compact('user', 'data'));
@@ -241,32 +241,32 @@ class UserController extends Controller
      *
      * @param  CorrectionRequest  $request  修正後の日付・出退勤・休憩・備考を含むリクエスト
      * @param  int  $id  修正対象の勤怠レコードID
-     * @return RedirectResponse  修正申請一覧画面へのリダイレクト
+     * @return RedirectResponse 修正申請一覧画面へのリダイレクト
      */
     public function amendmentApplication(CorrectionRequest $request, int $id): RedirectResponse
     {
         $user = Auth::user();
         $application = Application::create([
-            'user_id'              => $user->id,
+            'user_id' => $user->id,
             'attendance_record_id' => $id,
-            'approval_status'      => '承認待ち',
-            'application_date'     => now(),
-            'new_date'             => Carbon::createFromFormat('n月j日', $request->new_date)
-                                        ->year(now()->year)
-                                        ->format('Y-m-d'),
-            'new_clock_in'         => Carbon::parse($request->new_clock_in)->format('H:i'),
-            'new_clock_out'        => Carbon::parse($request->new_clock_out)->format('H:i'),
-            'comment'              => $request->comment,
+            'approval_status' => '承認待ち',
+            'application_date' => now(),
+            'new_date' => Carbon::createFromFormat('n月j日', $request->new_date)
+                ->year(now()->year)
+                ->format('Y-m-d'),
+            'new_clock_in' => Carbon::parse($request->new_clock_in)->format('H:i'),
+            'new_clock_out' => Carbon::parse($request->new_clock_out)->format('H:i'),
+            'comment' => $request->comment,
         ]);
 
         // 申請用休憩を作成
-        $rawIns  = (array) $request->input('new_break_in', []);
+        $rawIns = (array) $request->input('new_break_in', []);
         $rawOuts = (array) $request->input('new_break_out', []);
         $pairs = [];
         foreach (array_values(array_filter($rawIns)) as $i => $in) {
             $out = array_values(array_filter($rawOuts))[$i] ?? null;
             $pairs[] = [
-                'break_in'  => Carbon::parse($in)->format('H:i'),
+                'break_in' => Carbon::parse($in)->format('H:i'),
                 'break_out' => $out ? Carbon::parse($out)->format('H:i') : null,
             ];
         }
@@ -278,26 +278,26 @@ class UserController extends Controller
     /**
      * ログインユーザーの修正申請一覧を表示する。
      *
-     * @return View  修正申請一覧画面のビュー
+     * @return View 修正申請一覧画面のビュー
      */
     public function applicationList(): View
     {
-        $user         = Auth::user();
+        $user = Auth::user();
         $applications = Application::where('user_id', $user->id)->get();
 
         // 一覧表示のために必要なデータを取得
         $formattedApplications = $applications->map(function ($application) {
             return [
-                'id'            => $application->id,
+                'id' => $application->id,
                 'application_date' => $application->application_date
                                 ? Carbon::parse($application->application_date)->format('Y/m/d')
                                 : null,
-                'date'          => $application->new_date
+                'date' => $application->new_date
                                 ? Carbon::parse($application->new_date)->format('Y/m/d')
                                 : null,
-                'clock_in'      => $application->new_clock_in,
-                'clock_out'     => $application->new_clock_out,
-                'comment'       => $application->comment,
+                'clock_in' => $application->new_clock_in,
+                'clock_out' => $application->new_clock_out,
+                'comment' => $application->comment,
                 'approval_status' => $application->approval_status,
             ];
         });
@@ -312,7 +312,7 @@ class UserController extends Controller
      * 修正申請の詳細画面を表示する。
      *
      * @param  int  $id  対象の修正申請ID
-     * @return View  修正申請詳細画面のビュー
+     * @return View 修正申請詳細画面のビュー
      */
     public function applicationDetail(int $id): View
     {
@@ -321,28 +321,28 @@ class UserController extends Controller
 
         $proposalBreaks = $application->proposalBreaks()->get()->map(function ($break) {
             return [
-                'break_in'  => $break->break_in ? Carbon::parse($break->break_in)->format('H:i') : null,
+                'break_in' => $break->break_in ? Carbon::parse($break->break_in)->format('H:i') : null,
                 'break_out' => $break->break_out ? Carbon::parse($break->break_out)->format('H:i') : null,
             ];
         })->toArray();
 
         $data = [
-            'id'            => $application->id,
-            'year'          => $application->new_date
+            'id' => $application->id,
+            'year' => $application->new_date
                                 ? Carbon::parse($application->new_date)->format('Y年')
                                 : null,
-            'date'          => $application->new_date
+            'date' => $application->new_date
                                 ? Carbon::parse($application->new_date)->format('n月j日')
                                 : null,
-            'clock_in'      => $application->new_clock_in
+            'clock_in' => $application->new_clock_in
                                 ? Carbon::parse($application->new_clock_in)->format('H:i')
                                 : null,
-            'clock_out'     => $application->new_clock_out
+            'clock_out' => $application->new_clock_out
                                 ? Carbon::parse($application->new_clock_out)->format('H:i')
                                 : null,
-            'breaks'        => $proposalBreaks,
-            'comment'       => $application->comment,
-            'application'   => $application,
+            'breaks' => $proposalBreaks,
+            'comment' => $application->comment,
+            'application' => $application,
         ];
 
         return view('user/user-detail', compact('user', 'data'));

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,7 +2,31 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\AdminStatusMiddleware;
+use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\PreventRequestsDuringMaintenance;
+use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\TrimStrings;
+use App\Http\Middleware\TrustProxies;
+use App\Http\Middleware\ValidateSignature;
+use App\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
+use Illuminate\Auth\Middleware\Authorize;
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
+use Illuminate\Auth\Middleware\RequirePassword;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
+use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Http\Middleware\SetCacheHeaders;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class Kernel extends HttpKernel
 {
@@ -15,12 +39,12 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
-        \App\Http\Middleware\TrustProxies::class,
-        \Illuminate\Http\Middleware\HandleCors::class,
-        \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
-        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
-        \App\Http\Middleware\TrimStrings::class,
-        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        TrustProxies::class,
+        HandleCors::class,
+        PreventRequestsDuringMaintenance::class,
+        ValidatePostSize::class,
+        TrimStrings::class,
+        ConvertEmptyStringsToNull::class,
     ];
 
     /**
@@ -30,18 +54,18 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\EncryptCookies::class,
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \App\Http\Middleware\VerifyCsrfToken::class,
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            EncryptCookies::class,
+            AddQueuedCookiesToResponse::class,
+            StartSession::class,
+            ShareErrorsFromSession::class,
+            VerifyCsrfToken::class,
+            SubstituteBindings::class,
         ],
 
         'api' => [
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
-            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            ThrottleRequests::class.':api',
+            SubstituteBindings::class,
         ],
     ];
 
@@ -53,17 +77,17 @@ class Kernel extends HttpKernel
      * @var array<string, class-string|string>
      */
     protected $middlewareAliases = [
-        'auth' => \App\Http\Middleware\Authenticate::class,
-        'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-        'auth.session' => \Illuminate\Session\Middleware\AuthenticateSession::class,
-        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
-        'can' => \Illuminate\Auth\Middleware\Authorize::class,
-        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
-        'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
-        'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
-        'signed' => \App\Http\Middleware\ValidateSignature::class,
-        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'admin' => \App\Http\Middleware\AdminStatusMiddleware::class,
+        'auth' => Authenticate::class,
+        'auth.basic' => AuthenticateWithBasicAuth::class,
+        'auth.session' => AuthenticateSession::class,
+        'cache.headers' => SetCacheHeaders::class,
+        'can' => Authorize::class,
+        'guest' => RedirectIfAuthenticated::class,
+        'password.confirm' => RequirePassword::class,
+        'precognitive' => HandlePrecognitiveRequests::class,
+        'signed' => ValidateSignature::class,
+        'throttle' => ThrottleRequests::class,
+        'verified' => EnsureEmailIsVerified::class,
+        'admin' => AdminStatusMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/AdminStatusMiddleware.php
+++ b/app/Http/Middleware/AdminStatusMiddleware.php
@@ -3,16 +3,17 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 class AdminStatusMiddleware
 {
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
-     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     * @param  Closure(Request): (Response|RedirectResponse)  $next
+     * @return Response|RedirectResponse
      */
     public function handle(Request $request, Closure $next)
     {

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -13,7 +13,7 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next, string ...$guards): Response
     {

--- a/app/Http/Requests/AdminLoginRequest.php
+++ b/app/Http/Requests/AdminLoginRequest.php
@@ -8,8 +8,6 @@ class AdminLoginRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
-     *
-     * @return bool
      */
     public function authorize(): bool
     {
@@ -18,14 +16,12 @@ class AdminLoginRequest extends FormRequest
 
     /**
      * Get the validation rules that apply to the request.
-     *
-     * @return array
      */
     public function rules(): array
     {
         return [
-            'email' => "required|email",
-            'password' => "required|min:8"
+            'email' => 'required|email',
+            'password' => 'required|min:8',
         ];
     }
 
@@ -35,7 +31,7 @@ class AdminLoginRequest extends FormRequest
             'email.required' => 'メールアドレスを入力してください',
             'email.email' => 'メールアドレスはメール形式で入力してください',
             'password.required' => 'パスワードを入力してください',
-            'password.min' => 'パスワードは8文字以上で入力してください'
+            'password.min' => 'パスワードは8文字以上で入力してください',
         ];
     }
 }

--- a/app/Http/Requests/CorrectionRequest.php
+++ b/app/Http/Requests/CorrectionRequest.php
@@ -8,8 +8,6 @@ class CorrectionRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
-     *
-     * @return bool
      */
     public function authorize(): bool
     {
@@ -18,42 +16,40 @@ class CorrectionRequest extends FormRequest
 
     /**
      * Get the validation rules that apply to the request.
-     *
-     * @return array
      */
     public function rules(): array
     {
         return [
-            'new_clock_in'  => 'required|date_format:H:i',
+            'new_clock_in' => 'required|date_format:H:i',
             'new_clock_out' => 'required|date_format:H:i|after:new_clock_in',
 
-            'new_break_in'   => 'nullable|array',
-            'new_break_out'  => 'nullable|array',
+            'new_break_in' => 'nullable|array',
+            'new_break_out' => 'nullable|array',
 
             // 各要素が出勤後・退勤前であることをチェック
-            'new_break_in.*'  => 'nullable|date_format:H:i|after:new_clock_in|before:new_clock_out',
+            'new_break_in.*' => 'nullable|date_format:H:i|after:new_clock_in|before:new_clock_out',
             'new_break_out.*' => 'nullable|date_format:H:i|after:new_clock_in|before:new_clock_out',
 
-            'comment'       => 'required',
+            'comment' => 'required',
         ];
     }
 
     public function messages(): array
     {
         return [
-            'new_clock_in.required'    => '出勤時間を入力してください。',
+            'new_clock_in.required' => '出勤時間を入力してください。',
             'new_clock_in.date_format' => '出勤時間は「HH:mm」形式で入力してください。',
-            'new_clock_out.required'   => '退勤時間を入力してください。',
-            'new_clock_out.date_format'=> '退勤時間は「HH:mm」形式で入力してください。',
-            'new_clock_out.after'      => '出勤時間もしくは退勤時間が不適切な値です。',
+            'new_clock_out.required' => '退勤時間を入力してください。',
+            'new_clock_out.date_format' => '退勤時間は「HH:mm」形式で入力してください。',
+            'new_clock_out.after' => '出勤時間もしくは退勤時間が不適切な値です。',
 
-            'new_break_in.*.date_format'  => '休憩開始は「HH:mm」形式で入力してください。',
-            'new_break_in.*.before'       => '休憩時間が不適切な値です。',
-            'new_break_in.*.after'        => '休憩時間が不適切な値です。',
+            'new_break_in.*.date_format' => '休憩開始は「HH:mm」形式で入力してください。',
+            'new_break_in.*.before' => '休憩時間が不適切な値です。',
+            'new_break_in.*.after' => '休憩時間が不適切な値です。',
 
             'new_break_out.*.date_format' => '休憩終了は「HH:mm」形式で入力してください。',
-            'new_break_out.*.before'      => '休憩時間もしくは退勤時間が不適切な値です',
-            'new_break_out.*.after'       => '休憩時間もしくは退勤時間が不適切な値です',
+            'new_break_out.*.before' => '休憩時間もしくは退勤時間が不適切な値です',
+            'new_break_out.*.after' => '休憩時間もしくは退勤時間が不適切な値です',
 
             'comment.required' => '備考を記入してください。',
         ];

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -8,8 +8,6 @@ class LoginRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
-     *
-     * @return bool
      */
     public function authorize(): bool
     {
@@ -18,8 +16,6 @@ class LoginRequest extends FormRequest
 
     /**
      * Get the validation rules that apply to the request.
-     *
-     * @return array
      */
     public function rules(): array
     {
@@ -35,7 +31,7 @@ class LoginRequest extends FormRequest
             'email.required' => 'メールアドレスを入力してください',
             'email.email' => 'メールアドレスはメール形式で入力してください',
             'password.required' => 'パスワードを入力してください',
-            'password.min' => 'パスワードは8文字以上で入力してください'
+            'password.min' => 'パスワードは8文字以上で入力してください',
         ];
     }
 }

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -8,8 +8,6 @@ class RegisterRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
-     *
-     * @return bool
      */
     public function authorize(): bool
     {
@@ -18,8 +16,6 @@ class RegisterRequest extends FormRequest
 
     /**
      * Get the validation rules that apply to the request.
-     *
-     * @return array
      */
     public function rules(): array
     {
@@ -27,7 +23,7 @@ class RegisterRequest extends FormRequest
             'name' => 'required',
             'email' => 'required|email',
             'password' => 'required|min:8|confirmed',
-            'password_confirmation' => 'required|min:8'
+            'password_confirmation' => 'required|min:8',
         ];
     }
 
@@ -41,7 +37,7 @@ class RegisterRequest extends FormRequest
             'password.min' => 'パスワードは8文字以上で入力してください',
             'password.confirmed' => 'パスワードと一致しません',
             'password_confirmation.required' => 'パスワードを入力してください',
-            'password_confirmation.min' => 'パスワードは8文字以上で入力してください'
+            'password_confirmation.min' => 'パスワードは8文字以上で入力してください',
         ];
     }
 }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -19,7 +19,7 @@ class Application extends Model
         'new_date',
         'new_clock_in',
         'new_clock_out',
-        'comment'
+        'comment',
     ];
 
     /**

--- a/app/Models/ApplicationBreak.php
+++ b/app/Models/ApplicationBreak.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class ApplicationBreak extends Model
 {
     protected $table = 'application_breaks';
+
     protected $fillable = ['application_id', 'break_in', 'break_out'];
 
     /**

--- a/app/Models/AttendanceRecord.php
+++ b/app/Models/AttendanceRecord.php
@@ -22,11 +22,11 @@ class AttendanceRecord extends Model
     ];
 
     protected $casts = [
-        'date'              => 'datetime',
-        'clock_in'          => 'datetime:H:i',
-        'clock_out'         => 'datetime:H:i',
-        'total_time'        => 'string',
-        'total_break_time'  => 'string',
+        'date' => 'datetime',
+        'clock_in' => 'datetime:H:i',
+        'clock_out' => 'datetime:H:i',
+        'total_time' => 'string',
+        'total_break_time' => 'string',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -22,7 +22,7 @@ class User extends Authenticatable
         'email',
         'password',
         'admin_status',
-        'attendance_status'
+        'attendance_status',
     ];
 
     /**
@@ -47,7 +47,7 @@ class User extends Authenticatable
     /**
      * このユーザーの勤怠レコード。
      */
-    public function attendanceRecords(): \Illuminate\Database\Eloquent\Relations\HasMany
+    public function attendanceRecords(): HasMany
     {
         return $this->hasMany(AttendanceRecord::class);
     }
@@ -55,7 +55,7 @@ class User extends Authenticatable
     /**
      * このユーザーが行った修正申請。
      */
-    public function applications(): \Illuminate\Database\Eloquent\Relations\HasMany
+    public function applications(): HasMany
     {
         return $this->hasMany(Application::class);
     }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -14,9 +14,7 @@ class FortifyServiceProvider extends ServiceProvider
     /**
      * Register any application services.
      */
-    public function register(): void
-    {
-    }
+    public function register(): void {}
 
     /**
      * Bootstrap any application services.
@@ -35,7 +33,8 @@ class FortifyServiceProvider extends ServiceProvider
 
         RateLimiter::for('login', function (Request $request) {
             $email = (string) $request->email;
-            return Limit::perMinute(10)->by($email . $request->ip());
+
+            return Limit::perMinute(10)->by($email.$request->ip());
         });
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,10 @@
 <?php
 
+use App\Exceptions\Handler;
+use App\Http\Kernel;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Application;
+
 /*
 |--------------------------------------------------------------------------
 | Create The Application
@@ -11,7 +16,7 @@
 |
 */
 
-$app = new Illuminate\Foundation\Application(
+$app = new Application(
     $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
 );
 
@@ -28,7 +33,7 @@ $app = new Illuminate\Foundation\Application(
 
 $app->singleton(
     Illuminate\Contracts\Http\Kernel::class,
-    App\Http\Kernel::class
+    Kernel::class
 );
 
 $app->singleton(
@@ -37,8 +42,8 @@ $app->singleton(
 );
 
 $app->singleton(
-    Illuminate\Contracts\Debug\ExceptionHandler::class,
-    App\Exceptions\Handler::class
+    ExceptionHandler::class,
+    Handler::class
 );
 
 /*

--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,10 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\AuthServiceProvider;
+use App\Providers\EventServiceProvider;
+use App\Providers\FortifyServiceProvider;
+use App\Providers\RouteServiceProvider;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 
@@ -163,12 +168,12 @@ return [
         /*
          * Application Service Providers...
          */
-        App\Providers\AppServiceProvider::class,
-        App\Providers\AuthServiceProvider::class,
+        AppServiceProvider::class,
+        AuthServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
-        App\Providers\EventServiceProvider::class,
-        App\Providers\RouteServiceProvider::class,
-        App\Providers\FortifyServiceProvider::class,
+        EventServiceProvider::class,
+        RouteServiceProvider::class,
+        FortifyServiceProvider::class,
     ])->toArray(),
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -68,7 +70,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => App\Models\User::class,
+            'model' => User::class,
         ],
 
         // 'users' => [

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -158,7 +158,7 @@ return [
     ],
 
     'redirects' => [
-        'logout' => config('app.url'). '/login'
-    ]
+        'logout' => config('app.url').'/login',
+    ],
 
 ];

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\VerifyCsrfToken;
+use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Sanctum;
 
 return [
@@ -75,9 +78,9 @@ return [
     */
 
     'middleware' => [
-        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
-        'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
-        'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
+        'authenticate_session' => AuthenticateSession::class,
+        'encrypt_cookies' => EncryptCookies::class,
+        'verify_csrf_token' => VerifyCsrfToken::class,
     ],
 
 ];

--- a/database/factories/AttendanceRecordFactory.php
+++ b/database/factories/AttendanceRecordFactory.php
@@ -2,10 +2,10 @@
 
 namespace Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\AttendanceRecord;
 use App\Models\User;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 class AttendanceRecordFactory extends Factory
 {
@@ -15,14 +15,14 @@ class AttendanceRecordFactory extends Factory
     {
         // ユーザーID
         $userIds = User::pluck('id');
-        $userId  = $userIds->random();
+        $userId = $userIds->random();
 
         // 日付と打刻（実際にはCarbonインスタンスを渡し、モデルのキャストでH:iに）
         // 直近3ヶ月のデータを生成する（採点時に「最近の勤怠」として確認できるように）
-        $date     = $this->faker->dateTimeBetween('-3 months', 'now')->format('Y-m-d');
-        $clockIn  = Carbon::createFromFormat('Y-m-d H:i:s', $date.' '.$this->faker->time('H:i:s'));
+        $date = $this->faker->dateTimeBetween('-3 months', 'now')->format('Y-m-d');
+        $clockIn = Carbon::createFromFormat('Y-m-d H:i:s', $date.' '.$this->faker->time('H:i:s'));
         $clockOut = Carbon::createFromFormat('Y-m-d H:i:s', $date.' '.$this->faker->time('H:i:s'))
-                      ->addHours(rand(6, 10)); // 出退勤間隔は6〜10時間のランダム
+            ->addHours(rand(6, 10)); // 出退勤間隔は6〜10時間のランダム
 
         // 休憩時間合計はあとで BreaksTableSeeder が入れるので、ここではゼロでもOK
         $totalBreakSeconds = 0;
@@ -31,13 +31,13 @@ class AttendanceRecordFactory extends Factory
         $workedSeconds = $clockOut->diffInSeconds($clockIn) - $totalBreakSeconds;
 
         return [
-            'user_id'            => $userId,
-            'date'               => $date,
-            'clock_in'           => $clockIn,
-            'clock_out'          => $clockOut,
-            'total_break_time'   => gmdate('H:i', $totalBreakSeconds),
-            'total_time'         => gmdate('H:i', $workedSeconds),
-            'comment'            => $this->faker->optional()->sentence(),
+            'user_id' => $userId,
+            'date' => $date,
+            'clock_in' => $clockIn,
+            'clock_out' => $clockOut,
+            'total_break_time' => gmdate('H:i', $totalBreakSeconds),
+            'total_time' => gmdate('H:i', $workedSeconds),
+            'comment' => $this->faker->optional()->sentence(),
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,7 +26,7 @@ class UserFactory extends Factory
     /**
      * Indicate that the model's email address should be unverified.
      *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     * @return Factory
      */
     public function unverified()
     {

--- a/database/seeders/AttendanceRecordsTableSeeder.php
+++ b/database/seeders/AttendanceRecordsTableSeeder.php
@@ -42,9 +42,13 @@ class AttendanceRecordsTableSeeder extends Seeder
 {
     /** [clock_in, clock_out, comment] 形式のパターン定義 */
     private const PATTERN_NORMAL = ['09:00:00', '18:00:00', '通常勤務'];
+
     private const PATTERN_OVERTIME = ['09:00:00', '20:00:00', '残業'];
+
     private const PATTERN_LATE = ['09:30:00', '18:00:00', '遅刻'];
+
     private const PATTERN_EARLY_LEAVE = ['09:00:00', '17:00:00', '早退'];
+
     private const PATTERN_LONG_WORK = ['08:00:00', '21:00:00', '長時間労働'];
 
     public function run(): void

--- a/database/seeders/BreaksTableSeeder.php
+++ b/database/seeders/BreaksTableSeeder.php
@@ -2,11 +2,11 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
-use App\Models\AttendanceRecord;
 use App\Models\AttendanceBreak;
-use Faker\Factory as Faker;
+use App\Models\AttendanceRecord;
 use Carbon\Carbon;
+use Faker\Factory as Faker;
+use Illuminate\Database\Seeder;
 
 class BreaksTableSeeder extends Seeder
 {
@@ -22,7 +22,7 @@ class BreaksTableSeeder extends Seeder
         // user1 のレコードは AttendanceRecordsTableSeeder で固定休憩 (12:00-13:00) を
         // 既に付与しているため、ここでは休憩がまだ無いレコード（user2/user3 のランダム）のみに付与する。
         AttendanceRecord::query()->whereDoesntHave('breaks')->each(function (AttendanceRecord $record) use ($faker) {
-            $clockIn  = Carbon::parse($record->clock_in);
+            $clockIn = Carbon::parse($record->clock_in);
             $clockOut = Carbon::parse(
                 $record->clock_out ?? $clockIn->copy()->addHours(8)
             );
@@ -36,15 +36,15 @@ class BreaksTableSeeder extends Seeder
 
             for ($i = 0; $i < $breakCount; $i++) {
                 $startStr = $clockIn->format('Y-m-d H:i:s');
-                $endStr   = $clockOut->format('Y-m-d H:i:s');
+                $endStr = $clockOut->format('Y-m-d H:i:s');
                 $in = $faker->dateTimeBetween($startStr, $endStr);
                 $inStr = $in->format('Y-m-d H:i:s');
-                $out   = $faker->dateTimeBetween($inStr, $endStr);
+                $out = $faker->dateTimeBetween($inStr, $endStr);
 
                 AttendanceBreak::create([
                     'attendance_record_id' => $record->id,
-                    'break_in'             => Carbon::instance($in)->format('H:i:s'),
-                    'break_out'            => Carbon::instance($out)->format('H:i:s'),
+                    'break_in' => Carbon::instance($in)->format('H:i:s'),
+                    'break_out' => Carbon::instance($out)->format('H:i:s'),
                 ]);
             }
         });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,15 +1,14 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\UserController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\ReportController;
+use App\Http\Controllers\UserController;
 use App\Http\Middleware\AdminStatusMiddleware;
-use Laravel\Fortify\Http\Controllers\VerifyEmailController;
-use Illuminate\Http\Request;
 use App\Http\Requests\CorrectionRequest;
-
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Laravel\Fortify\Http\Controllers\VerifyEmailController;
 
 /*
 |--------------------------------------------------------------------------
@@ -50,18 +49,21 @@ Route::middleware(['auth', AdminStatusMiddleware::class])->group(function () {
         if (auth()->user()->admin_status) {
             return app(AdminController::class)->applicationList();
         }
+
         return app(UserController::class)->applicationList();
     });
     Route::get('/attendance/{id}', function ($id, Request $request) {
         if (auth()->user()->admin_status) {
             return app(AdminController::class)->detail($id);
         }
+
         return app(UserController::class)->detail($id);
     });
     Route::post('/attendance/{id}', function (CorrectionRequest $request, $id) {
         if (auth()->user()->admin_status) {
             return app(AdminController::class)->amendmentApplication($request, $id);
         }
+
         return app(UserController::class)->amendmentApplication($request, $id);
     });
 });
@@ -82,5 +84,6 @@ Route::get('/email/verify/{id}/{hash}', [VerifyEmailController::class, '__invoke
 // 認証メールの再送（メール認証誘導画面の「再送する」ボタン）
 Route::post('/email/verification-notification', function (Request $request) {
     $request->user()->sendEmailVerificationNotification();
+
     return back()->with('message', '認証メールを再送しました。');
 })->middleware(['auth', 'throttle:6,1'])->name('verification.send');

--- a/storage/framework/sessions/.gitignore
+++ b/storage/framework/sessions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -3,13 +3,14 @@
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
 
 trait CreatesApplication
 {
     /**
      * Creates the application.
      *
-     * @return \Illuminate\Foundation\Application
+     * @return Application
      */
     public function createApplication()
     {

--- a/tests/Feature/AdminAttendanceCorrectionTest.php
+++ b/tests/Feature/AdminAttendanceCorrectionTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Feature;
 
+use App\Models\Application;
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Faker\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\AttendanceRecord;
-use Database\Seeders\DatabaseSeeder;
-use App\Models\Application;
 
 class AdminAttendanceCorrectionTest extends TestCase
 {
@@ -28,7 +29,7 @@ class AdminAttendanceCorrectionTest extends TestCase
         $users = User::all();
         $applications = [];
 
-        $faker = \Faker\Factory::create();
+        $faker = Factory::create();
 
         foreach ($users as $user) {
             for ($i = 0; $i < 3; $i++) {
@@ -68,7 +69,7 @@ class AdminAttendanceCorrectionTest extends TestCase
         $users = User::all();
         $applications = [];
 
-        $faker = \Faker\Factory::create();
+        $faker = Factory::create();
 
         foreach ($users as $user) {
             for ($i = 0; $i < 3; $i++) {
@@ -123,10 +124,10 @@ class AdminAttendanceCorrectionTest extends TestCase
             'new_clock_out' => '12:00',
             'attendance_record_id' => $attendanceRecord->id,
             'comment' => '修正理由テスト',
-            'application_date' => now()
+            'application_date' => now(),
         ]);
 
-        $response = $this->get('/stamp_correction_request/approve/' . $application->id);
+        $response = $this->get('/stamp_correction_request/approve/'.$application->id);
 
         $response->assertSee($application->new_clock_in);
         $response->assertSee($application->new_clock_out);
@@ -156,14 +157,13 @@ class AdminAttendanceCorrectionTest extends TestCase
             'new_clock_out' => '12:00',
             'attendance_record_id' => $attendanceRecord->id,
             'comment' => '修正理由テスト',
-            'application_date' => now()
+            'application_date' => now(),
         ]);
 
-        $response = $this->get('/stamp_correction_request/approve/' . $application->id);
-        $response = $this->post('/stamp_correction_request/approve/' . $application->id);
+        $response = $this->get('/stamp_correction_request/approve/'.$application->id);
+        $response = $this->post('/stamp_correction_request/approve/'.$application->id);
 
-
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
         $response->assertSee('10:00');
         $response->assertSee('12:00');
     }

--- a/tests/Feature/AdminAttendanceDetailTest.php
+++ b/tests/Feature/AdminAttendanceDetailTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\AttendanceRecord;
-use Database\Seeders\DatabaseSeeder;
 
 class AdminAttendanceDetailTest extends TestCase
 {
@@ -30,7 +30,7 @@ class AdminAttendanceDetailTest extends TestCase
 
         $response = $this->get('/admin/attendance/list');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
         $response->assertStatus(200);
         $response->assertSee($user->name);
@@ -48,12 +48,12 @@ class AdminAttendanceDetailTest extends TestCase
 
         $response = $this->get('/admin/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '10:00',
             'new_clock_out' => '09:00',
-            'comment' => 'テストコメント'
+            'comment' => 'テストコメント',
         ]);
 
         $response->assertSessionHasErrors(['new_clock_out']);
@@ -72,14 +72,14 @@ class AdminAttendanceDetailTest extends TestCase
 
         $response = $this->get('/admin/attendance');
 
-        $response = $this->get('/admin/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/admin/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '09:00',
             'new_clock_out' => '15:00',
             'new_break_in' => ['16:00'],
             'new_break_out' => ['15:30'],
-            'comment' => 'Test comment'
+            'comment' => 'Test comment',
         ]);
 
         $response->assertSessionHasErrors(['new_break_in.0']);
@@ -98,14 +98,14 @@ class AdminAttendanceDetailTest extends TestCase
 
         $response = $this->get('/admin/attendance');
 
-        $response = $this->get('/admin/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/admin/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '09:00',
             'new_clock_out' => '15:00',
             'new_break_in' => ['10:00'],
             'new_break_out' => ['16:00'],
-            'comment' => 'Test comment'
+            'comment' => 'Test comment',
         ]);
 
         $response->assertSessionHasErrors(['new_break_out.0']);
@@ -124,17 +124,15 @@ class AdminAttendanceDetailTest extends TestCase
 
         $response = $this->get('/admin/attendance');
 
-        $response = $this->get('/admin/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/admin/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '9:00',
             'new_clock_out' => '15:00',
-            'comment' => ''
+            'comment' => '',
         ]);
 
         $response->assertSessionHasErrors(['comment']);
         $this->assertContains('備考を記入してください。', session('errors')->get('comment'));
     }
 }
-
-

--- a/tests/Feature/AdminAttendanceTest.php
+++ b/tests/Feature/AdminAttendanceTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\AttendanceRecord;
+use App\Models\User;
 use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Tests\TestCase;
 
 class AdminAttendanceTest extends TestCase
 {
@@ -63,7 +63,7 @@ class AdminAttendanceTest extends TestCase
 
         $attendanceRecords = AttendanceRecord::whereDate('date', $previousDay)->get();
 
-        $response = $this->get('/admin/attendance/list?date=' . $previousDay->format('Y-m-d'));
+        $response = $this->get('/admin/attendance/list?date='.$previousDay->format('Y-m-d'));
 
         foreach ($attendanceRecords as $record) {
             $response->assertSee($record->user->name);
@@ -86,7 +86,7 @@ class AdminAttendanceTest extends TestCase
 
         $attendanceRecords = AttendanceRecord::whereDate('date', $nextDay)->get();
 
-        $response = $this->get('/admin/attendance/list?date=' . $nextDay->format('Y-m-d'));
+        $response = $this->get('/admin/attendance/list?date='.$nextDay->format('Y-m-d'));
 
         foreach ($attendanceRecords as $record) {
             $response->assertSee($record->user->name);

--- a/tests/Feature/AdminLoginTest.php
+++ b/tests/Feature/AdminLoginTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
 
 class AdminLoginTest extends TestCase
 {
@@ -20,11 +20,11 @@ class AdminLoginTest extends TestCase
 
         $response = $this->post('/admin/login', [
             'email' => '',
-            'password' => 'password123'
+            'password' => 'password123',
         ]);
 
         $response->assertSessionHasErrors(['email']);
-        $this->assertContains('メールアドレスを入力してください' , session()->get('errors')->get('email'));
+        $this->assertContains('メールアドレスを入力してください', session()->get('errors')->get('email'));
     }
 
     /** @test */
@@ -37,11 +37,11 @@ class AdminLoginTest extends TestCase
 
         $response = $this->post('/admin/login', [
             'email' => 'test@example.com',
-            'password' => ''
+            'password' => '',
         ]);
 
         $response->assertSessionHasErrors(['password']);
-        $this->assertContains('パスワードを入力してください' , session()->get('errors')->get('password'));
+        $this->assertContains('パスワードを入力してください', session()->get('errors')->get('password'));
     }
 
     /** @test */
@@ -54,7 +54,7 @@ class AdminLoginTest extends TestCase
 
         $response = $this->post('/admin/login', [
             'email' => 'test@example',
-            'password' => 'password123'
+            'password' => 'password123',
         ]);
 
         $response->assertSessionHasErrors(['email']);
@@ -62,4 +62,3 @@ class AdminLoginTest extends TestCase
         $this->assertContains('ログイン情報が登録されていません', $errors);
     }
 }
-

--- a/tests/Feature/Api/V1/AttendanceRecordApiTest.php
+++ b/tests/Feature/Api/V1/AttendanceRecordApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api\V1;
 
 use App\Models\AttendanceRecord;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
@@ -148,7 +149,7 @@ class AttendanceRecordApiTest extends TestCase
         $record = AttendanceRecord::where('user_id', $user->id)->latest('id')->first();
         $this->assertNotNull($record);
         $this->assertSame('2026-05-15', $record->date->format('Y-m-d'));
-        $this->assertSame('09:00', \Carbon\Carbon::parse($record->clock_in)->format('H:i'));
+        $this->assertSame('09:00', Carbon::parse($record->clock_in)->format('H:i'));
     }
 
     /** @test */

--- a/tests/Feature/AttendanceStatusTest.php
+++ b/tests/Feature/AttendanceStatusTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
 
 class AttendanceStatusTest extends TestCase
 {

--- a/tests/Feature/AttendanceTest.php
+++ b/tests/Feature/AttendanceTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Database\Seeders\UsersTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use Database\Seeders\UsersTableSeeder;
-use App\Models\User;
-use App\Models\AttendanceRecord;
 
 class AttendanceTest extends TestCase
 {
@@ -31,7 +31,7 @@ class AttendanceTest extends TestCase
 
         $this->assertDatabaseHas('users', [
             'id' => $user->id,
-            'attendance_status' => '出勤中'
+            'attendance_status' => '出勤中',
         ]);
     }
 

--- a/tests/Feature/BreakTest.php
+++ b/tests/Feature/BreakTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Database\Seeders\UsersTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\AttendanceRecord;
-use Database\Seeders\UsersTableSeeder;
 
 class BreakTest extends TestCase
 {

--- a/tests/Feature/CertificationTest.php
+++ b/tests/Feature/CertificationTest.php
@@ -20,7 +20,7 @@ class CertificationTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors(['name']);
-        $this->assertContains('お名前を入力してください' , session()->get('errors')->get('name'));
+        $this->assertContains('お名前を入力してください', session()->get('errors')->get('name'));
     }
 
     /** @test */
@@ -34,7 +34,7 @@ class CertificationTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors(['email']);
-        $this->assertContains('メールアドレスを入力してください' , session()->get('errors')->get('email'));
+        $this->assertContains('メールアドレスを入力してください', session()->get('errors')->get('email'));
     }
 
     /** @test */
@@ -48,7 +48,7 @@ class CertificationTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors(['password']);
-        $this->assertContains('パスワードは8文字以上で入力してください' , session()->get('errors')->get('password'));
+        $this->assertContains('パスワードは8文字以上で入力してください', session()->get('errors')->get('password'));
     }
 
     /** @test */
@@ -62,7 +62,7 @@ class CertificationTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors(['password']);
-        $this->assertContains('パスワードと一致しません' , session()->get('errors')->get('password'));
+        $this->assertContains('パスワードと一致しません', session()->get('errors')->get('password'));
     }
 
     /** @test */
@@ -76,7 +76,7 @@ class CertificationTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors(['password']);
-        $this->assertContains('パスワードを入力してください' , session()->get('errors')->get('password'));
+        $this->assertContains('パスワードを入力してください', session()->get('errors')->get('password'));
     }
 
     /** @test */

--- a/tests/Feature/GetDateAndTimeTest.php
+++ b/tests/Feature/GetDateAndTimeTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
+use Database\Seeders\UsersTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use Database\Seeders\UsersTableSeeder;
-use App\Models\User;
 
 class GetDateAndTimeTest extends TestCase
 {
@@ -25,7 +25,7 @@ class GetDateAndTimeTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $now = new \DateTime();
+        $now = new \DateTime;
         $week = [
             0 => '日',
             1 => '月',
@@ -37,7 +37,7 @@ class GetDateAndTimeTest extends TestCase
         ];
         $weekdayIndex = $now->format('w');
         $weekday = $week[$weekdayIndex];
-        $formattedDate = $now->format('Y年n月j日(' . $weekday . ')');
+        $formattedDate = $now->format('Y年n月j日('.$weekday.')');
         $formattedTime = $now->format('H:i');
 
         $response->assertSee($formattedDate);

--- a/tests/Feature/LeavingTest.php
+++ b/tests/Feature/LeavingTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Database\Seeders\UsersTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\AttendanceRecord;
-use Database\Seeders\UsersTableSeeder;
 
 class LeavingTest extends TestCase
 {

--- a/tests/Feature/UserAttendanceCorrectionTest.php
+++ b/tests/Feature/UserAttendanceCorrectionTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Feature;
 
+use App\Models\Application;
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Carbon\Carbon;
+use Database\Seeders\DatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\AttendanceRecord;
-use Database\Seeders\DatabaseSeeder;
-use Carbon\Carbon;
-use App\Models\Application;
 
 class UserAttendanceCorrectionTest extends TestCase
 {
@@ -30,12 +30,12 @@ class UserAttendanceCorrectionTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '10:00',
             'new_clock_out' => '9:00',
-            'comment' => 'Test comment'
+            'comment' => 'Test comment',
         ]);
 
         $response->assertSessionHasErrors(['new_clock_out']);
@@ -52,14 +52,14 @@ class UserAttendanceCorrectionTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '9:00',
             'new_clock_out' => '15:00',
             'new_break_in' => ['16:00'],
             'new_break_out' => ['15:30'],
-            'comment' => 'Test comment'
+            'comment' => 'Test comment',
         ]);
 
         $response->assertSessionHasErrors(['new_break_in.0']);
@@ -76,14 +76,14 @@ class UserAttendanceCorrectionTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '9:00',
             'new_clock_out' => '15:00',
             'new_break_in' => ['10:00'],
             'new_break_out' => ['16:00'],
-            'comment' => 'Test comment'
+            'comment' => 'Test comment',
         ]);
 
         $response->assertSessionHasErrors(['new_break_out.0']);
@@ -100,12 +100,12 @@ class UserAttendanceCorrectionTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '9:00',
             'new_clock_out' => '15:00',
-            'comment' => ''
+            'comment' => '',
         ]);
 
         $response->assertSessionHasErrors(['comment']);
@@ -128,15 +128,15 @@ class UserAttendanceCorrectionTest extends TestCase
             'new_date' => now(),
             'new_clock_in' => '09:00',
             'new_clock_out' => '15:00',
-            'comment' => 'テストコメント' ,
+            'comment' => 'テストコメント',
             'approval_status' => '承認待ち',
-    ]);
+        ]);
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '9:00',
             'new_clock_out' => '15:00',
             'comment' => 'テストコメント',
@@ -144,7 +144,7 @@ class UserAttendanceCorrectionTest extends TestCase
 
         $this->actingAs($admin);
 
-        $response = $this->get('/stamp_correction_request/approve/' . $application->id);
+        $response = $this->get('/stamp_correction_request/approve/'.$application->id);
         $response->assertStatus(200);
         $response->assertSee($user->name);
 
@@ -165,7 +165,7 @@ class UserAttendanceCorrectionTest extends TestCase
         $this->assertCount(2, $records);
 
         foreach ($records as $i => $record) {
-            $this->post('/attendance/' . $record->id, [
+            $this->post('/attendance/'.$record->id, [
                 'new_date' => Carbon::parse($record->date)->format('n月j日'),
                 'new_clock_in' => '09:00',
                 'new_clock_out' => '18:00',
@@ -203,10 +203,10 @@ class UserAttendanceCorrectionTest extends TestCase
             'new_clock_in' => '09:00',
             'new_clock_out' => '15:00',
             'comment' => 'テストコメント',
-            'approval_status' => '承認待ち'
+            'approval_status' => '承認待ち',
         ]);
 
-        $this->post('/attendance/' . $attendanceRecord->id, [
+        $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '09:00',
             'new_clock_out' => '15:00',
             'comment' => 'テストコメント',
@@ -233,14 +233,14 @@ class UserAttendanceCorrectionTest extends TestCase
 
         $attendanceRecord = AttendanceRecord::where('user_id', $user->id)->first();
 
-        $response = $this->post('/attendance/' . $attendanceRecord->id, [
+        $response = $this->post('/attendance/'.$attendanceRecord->id, [
             'new_clock_in' => '9:00',
             'new_clock_out' => '15:00',
             'comment' => 'テストコメント',
         ]);
 
         $response = $this->get('/stamp_correction_request/list');
-        $response = $this->get('attendance/' . $attendanceRecord->id);
+        $response = $this->get('attendance/'.$attendanceRecord->id);
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/UserAttendanceDetailTest.php
+++ b/tests/Feature/UserAttendanceDetailTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\AttendanceRecord;
+use Carbon\Carbon;
+use Database\Seeders\DatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\AttendanceRecord;
-use Database\Seeders\DatabaseSeeder;
-use Carbon\Carbon;
 
 class UserAttendanceDetailTest extends TestCase
 {
@@ -28,7 +28,7 @@ class UserAttendanceDetailTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
         $response->assertStatus(200);
         $response->assertSee($user->name);
@@ -44,7 +44,7 @@ class UserAttendanceDetailTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
         $response->assertStatus(200);
         $response->assertSee($attendanceRecord->date->format('n月j日'));
@@ -60,7 +60,7 @@ class UserAttendanceDetailTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
         $response->assertStatus(200);
         $response->assertSee(Carbon::parse($attendanceRecord->clock_in)->format('H:i'));
@@ -77,7 +77,7 @@ class UserAttendanceDetailTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
         $response->assertStatus(200);
         $response->assertSee(Carbon::parse($attendanceRecord->breaks[0]->break_in)->format('H:i'));

--- a/tests/Feature/UserAttendanceTest.php
+++ b/tests/Feature/UserAttendanceTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\AttendanceRecord;
-use Database\Seeders\DatabaseSeeder;
 
 class UserAttendanceTest extends TestCase
 {
@@ -82,7 +82,7 @@ class UserAttendanceTest extends TestCase
         ]);
 
         // 「前月」ボタン押下に相当：前月を指定して遷移する
-        $response = $this->get('/attendance/list?date=' . $previousMonth->format('Y-m-d'));
+        $response = $this->get('/attendance/list?date='.$previousMonth->format('Y-m-d'));
 
         $response->assertStatus(200);
         $response->assertSee($previousMonth->format('Y/m'));
@@ -104,7 +104,7 @@ class UserAttendanceTest extends TestCase
         ]);
 
         // 「翌月」ボタン押下に相当：翌月を指定して遷移する
-        $response = $this->get('/attendance/list?date=' . $nextMonth->format('Y-m-d'));
+        $response = $this->get('/attendance/list?date='.$nextMonth->format('Y-m-d'));
 
         $response->assertStatus(200);
         $response->assertSee($nextMonth->format('Y/m'));
@@ -121,7 +121,7 @@ class UserAttendanceTest extends TestCase
 
         $response = $this->get('/attendance');
 
-        $response = $this->get('/attendance/' . $attendanceRecord->id);
+        $response = $this->get('/attendance/'.$attendanceRecord->id);
 
         $response->assertStatus(200);
         $response->assertSee($attendanceRecord->date->format('n月j日'));

--- a/tests/Feature/UserInformationTest.php
+++ b/tests/Feature/UserInformationTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Carbon\Carbon;
+use Database\Seeders\DatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\AttendanceRecord;
-use Database\Seeders\DatabaseSeeder;
-use Carbon\Carbon;
 
 class UserInformationTest extends TestCase
 {
@@ -46,7 +46,7 @@ class UserInformationTest extends TestCase
         $attendanceRecords = AttendanceRecord::where('user_id', $user->id);
 
         $response = $this->get('/admin/staff/list');
-        $response = $this->get('/admin/attendance/staff/' . $user->id);
+        $response = $this->get('/admin/attendance/staff/'.$user->id);
 
         $response->assertStatus(200);
         foreach ($attendanceRecords as $record) {
@@ -70,7 +70,7 @@ class UserInformationTest extends TestCase
 
         $attendanceRecords = AttendanceRecord::whereDate('date', $previousMonth)->get();
 
-        $response = $this->get('/admin/attendance/list?date=' . $previousMonth->format('Y-m-d'));
+        $response = $this->get('/admin/attendance/list?date='.$previousMonth->format('Y-m-d'));
 
         foreach ($attendanceRecords as $record) {
             $response->assertSee($record->user->name);
@@ -94,7 +94,7 @@ class UserInformationTest extends TestCase
 
         $attendanceRecords = AttendanceRecord::whereDate('date', $nextMonth)->get();
 
-        $response = $this->get('/admin/attendance/list?date=' . $nextMonth->format('Y-m-d'));
+        $response = $this->get('/admin/attendance/list?date='.$nextMonth->format('Y-m-d'));
 
         foreach ($attendanceRecords as $record) {
             $response->assertSee($record->user->name);
@@ -112,13 +112,11 @@ class UserInformationTest extends TestCase
 
         $user = User::all()->random();
 
-        $response = $this->get('/admin/attendance/staff/' . $user->id);
+        $response = $this->get('/admin/attendance/staff/'.$user->id);
 
         $attendanceRecords = AttendanceRecord::all()->random();
 
-        $response = $this->get('/attendance/' . $attendanceRecords->id);
+        $response = $this->get('/attendance/'.$attendanceRecords->id);
         $response->assertStatus(200);
     }
 }
-
-

--- a/tests/Feature/UserLoginTest.php
+++ b/tests/Feature/UserLoginTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
 
 class UserLoginTest extends TestCase
 {
@@ -20,11 +20,11 @@ class UserLoginTest extends TestCase
 
         $response = $this->post('/login', [
             'email' => '',
-            'password' => 'password123'
+            'password' => 'password123',
         ]);
 
         $response->assertSessionHasErrors(['email']);
-        $this->assertContains('メールアドレスを入力してください' , session()->get('errors')->get('email'));
+        $this->assertContains('メールアドレスを入力してください', session()->get('errors')->get('email'));
     }
 
     /** @test */
@@ -37,11 +37,11 @@ class UserLoginTest extends TestCase
 
         $response = $this->post('/login', [
             'email' => 'test@example.com',
-            'password' => ''
+            'password' => '',
         ]);
 
         $response->assertSessionHasErrors(['password']);
-        $this->assertContains('パスワードを入力してください' , session()->get('errors')->get('password'));
+        $this->assertContains('パスワードを入力してください', session()->get('errors')->get('password'));
     }
 
     /** @test */
@@ -54,7 +54,7 @@ class UserLoginTest extends TestCase
 
         $response = $this->post('/login', [
             'email' => 'test@example',
-            'password' => 'password123'
+            'password' => 'password123',
         ]);
 
         $response->assertSessionHasErrors(['email']);


### PR DESCRIPTION
## なにを直したか

新カリキュラム版の模範解答を自動採点ハーネスに通したところ、**111項目中 52 が FALSE** になりました。
そのうち **51 はこのリポジトリ側の問題**でした（採点ロジックの誤りではありません）。3点あります。

| # | 症状 | 根因 |
|---|---|---|
| 1 | **全画面が 500**（結果として画面系の判定 32件が FALSE） | `storage/framework/sessions/` が存在しない |
| 2 | **テストが1件も走らない**（テスト系の判定 19件が FALSE） | `tests/Unit/` が存在しないのに `phpunit.xml` が宣言している |
| 3 | コード品質の1件が FALSE | `sail bin pint --test` が通っていない（43ファイル未整形） |

修正後に同じ検証を回すと **TRUE=109 / FALSE=0** になりました（残る2件は仕様上の人手確認・材料未指定ぶんで、模範解答の問題ではありません）。

## 1・2 について — なぜ気づきにくいか

**git は空ディレクトリを保存しません。** ローカルの作業ツリーには残っているので、開発している側からは
まったく見えません。`git clone`（または `git archive`）した瞬間にディレクトリごと消えます。

`storage/framework/sessions/` が無いと、セッションを書けずに全画面がこうなります:

```
ErrorException
file_put_contents(/var/www/html/storage/framework/sessions/xxxxxxxx):
Failed to open stream: No such file or directory
```

**`artisan migrate` も `db:seed` も sessions を使わないので、環境構築の手順は最後まで通ります。**
ブラウザで開いたときにだけ分かります。Laravel の標準スケルトンにはこのディレクトリを保持するための
`.gitignore` が入っていますが、このリポジトリには入っていませんでした（旧カリキュラム版の
`0b0f771` には入っています）。

`tests/Unit/` も同じで、`phpunit.xml` が

```xml
<testsuite name="Unit">
    <directory>tests/Unit</directory>
</testsuite>
```

を宣言しているのに実体が無いため、PHPUnit 10 は

```
Test directory "/var/www/html/tests/Unit" not found
```

でエラー終了します。**Feature の分も含めて1件も走りません。**

`.gitignore` ではなく `.gitkeep` を置いたのは、`*` を無視する `.gitignore` を入れると
後から `tests/Unit/` に追加したテストが黙って追跡対象外になるためです。

## 3 について

評価シートのコード品質の行が **`sail bin pint --test` が通ること**を評価基準にしているので、
模範解答がそれを満たしていないと、その行は模範解答でも 0 点になります。

適用したのは `vendor/bin/pint`（v1.29.3・`pint.json` なし＝既定の laravel preset）そのままです。
入っている fixer は整形系のみで挙動は変わりません（`ordered_imports` / `no_unused_imports` /
`trailing_comma_in_multiline` / `concat_space` / `fully_qualified_strict_types` ほか）。
適用後に `vendor/bin/pint --test` が 108ファイル PASS、変更した43ファイルすべて `php -l` OK です。

差分が大きいのは整形コミット（`d9f8ac2`）だけなので、**コミット単位で見ていただくのが早い**と思います。

## 受講生側でも起こりうる話

1 と 2 は環境構築の手順が最後まで通ってしまうため、受講生の提出でも同じことが起きると
**理由が見えないまま大量に不合格になります**。採点ハーネス側にも、ブラウザから見た画面が
5xx のときにそれを採点者へ出す診断を入れました（判定は変えず、理由が見えるようにするだけ）。